### PR TITLE
add monthly leaderboard + toggling between weekly/monthly

### DIFF
--- a/cc/text-example.cc
+++ b/cc/text-example.cc
@@ -84,12 +84,24 @@ void DisplayLeaderboard(RGBMatrix * canvas,
   // Loop over the array, displaying username & points
   int rank = 1;
   for (auto & item: leaderboard) {
-    std::string username = item.value("username", "unknown");
-    if (username.length() > 10) {
-      username = username.substr(0, 10); // Cut to 15 characters max
-    }
-    int points = item.value("points", 0);
+    std::string username = "unknown";
+    int points = 0;
 
+    try {
+      if (item.contains("user") && item["user"].is_string()) {
+        username = item["user"];
+      }
+      if (item.contains("points") && item["points"].is_number_integer()) {
+        points = item["points"];
+      }
+    } catch (const std::exception & e) {
+      fprintf(stderr, "Error parsing leaderboard item: %s\n", e.what());
+    }
+
+    if (username.length() > 10) {
+      username = username.substr(0, 10); // Cut to 10 characters max
+    }
+    
     // Display rank. If you don't want rank, just remove `%2d.` from the format
     char buffer[64];
     snprintf(buffer, sizeof(buffer), "%2d. %-10s %10d",

--- a/cc/text-example.cc
+++ b/cc/text-example.cc
@@ -84,7 +84,7 @@ void DisplayLeaderboard(RGBMatrix * canvas,
   // Loop over the array, displaying username & points
   int rank = 1;
   for (auto & item: leaderboard) {
-    std::string username = item.value("user", "unknown");
+    std::string username = item.value("username", "unknown");
     if (username.length() > 10) {
       username = username.substr(0, 10); // Cut to 15 characters max
     }

--- a/modules/sqlite_helpers.py
+++ b/modules/sqlite_helpers.py
@@ -74,7 +74,7 @@ def maybe_create_table(sqlite_file: str) -> bool:
     return True
 
 
-def get_users_as_leaderboard(
+def get_weekly_leaderboard(
     sqlite_file: str, start_date: str, end_date: str
 ) -> list[dict]:
     """
@@ -129,7 +129,70 @@ def get_users_as_leaderboard(
         for row in rows:
             result.append(
                 {
-                    "user": row["user_slug"],
+                    "username": row["user_slug"],
+                    "easy": row["easy_diff"],
+                    "medium": row["medium_diff"],
+                    "hard": row["hard_diff"],
+                }
+            )
+        return result
+    
+
+def get_monthly_leaderboard(
+    sqlite_file: str, start_date: str, end_date: str
+) -> list[dict]:
+    """
+    Returns the difference in easy/medium/hard between start_date and now
+    for each user in the users table.
+    """
+    query = """
+        WITH start_snap AS (
+            SELECT user_slug,
+                   easy AS easy_start,
+                   medium AS medium_start,
+                   hard AS hard_start)
+            FROM leetcode_snapshots s1
+            WHERE created_at = (
+                SELECT MIN(created_at)
+                FROM leetcode_snapshots s2
+                WHERE s2.user_slug = s1.user_slug
+                AND created_at >= :start_date
+            )
+        ),
+        end_snap AS (
+            SELECT user_slug,
+                   easy AS easy,
+                   medium AS medium,
+                   hard AS hard
+            FROM leetcode_snapshots s1
+            WHERE created_at = (
+                SELECT MAX(created_at)
+                FROM leetcode_snapshots s2
+                WHERE s2.user_slug = s1.user_slug
+                AND created_at <= :end_date
+            )
+        )
+        SELECT u.user_slug,
+               COALESCE(e.easy, 0) - COALESCE(s.easy_start, 0) AS easy_diff,
+               COALESCE(e.medium, 0) - COALESCE(s.medium_start, 0) AS medium_diff,
+               COALESCE(e.hard, 0) - COALESCE(s.hard_start, 0) AS hard_diff
+        FROM users u
+        LEFT JOIN start_snap s ON u.user_slug = s.user_slug
+        LEFT JOIN end_snap e ON u.user_slug = e.user_slug
+        where s.user_slug IS NOT NULL;
+    """
+
+    with sqlite3.connect(sqlite_file) as conn:
+        conn.row_factory = sqlite3.Row  # allows dict-like access
+        cursor = conn.cursor()
+        cursor.execute(query, {"start_date": start_date, "end_date": end_date})
+        rows = cursor.fetchall()
+
+        result = []
+        for row in rows:
+            result.append(
+                {
+                    "username": row["user_slug"],
                     "easy": row["easy_diff"],
                     "medium": row["medium_diff"],
                     "hard": row["hard_diff"],

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import uvicorn
 import threading
 import zoneinfo
 import time
+from enum import Enum
 
 from fastapi import FastAPI, HTTPException, Request, Response
 import yaml
@@ -22,6 +23,7 @@ logging.getLogger("uvicorn.error").setLevel(logging.WARNING)
 
 
 leetcode_stop_event = threading.Event()
+leaderboard_switch_stop_event = threading.Event()
 
 app = FastAPI()
 arguments = args.get_args()
@@ -34,6 +36,7 @@ with open(arguments.config, "r") as stream:
         PORT = data.get("port", 8000)
         SQLITE_FILE_NAME = data.get("sqlite3_file_name", "users.db")
         TIME_ZONE = data.get("local_timezone", "UTC")
+        QUERY_SWITCH_INTERVAL = data.get("query_switch_interval", 600)
         POINTS = data.get("points", {})
     except Exception:
         logger.exception("unable to open yaml file / file is missing data, exiting")
@@ -41,38 +44,60 @@ with open(arguments.config, "r") as stream:
 
 metrics_handler = MetricsHandler.instance()
 
+class LeaderboardType(Enum):
+    WEEKLY = "weekly"
+    MONTHLY = "monthly"
+
+current_leaderboard_type = LeaderboardType.WEEKLY
+
+
 @app.get("/")
 def leaderboard():
     try:
         tz = zoneinfo.ZoneInfo(TIME_ZONE)
         now_local = datetime.datetime.now(tz)
-        # Set start of week to Sunday 12am
-        days_since_sunday = now_local.weekday() + 1 if now_local.weekday() < 6 else 0
-        start_of_week_local = now_local - datetime.timedelta(days=days_since_sunday)
-        start_of_week_local = start_of_week_local.replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
+        if current_leaderboard_type == LeaderboardType.WEEKLY:
+            # Set start of week to Sunday 12am
+            days_since_sunday = now_local.weekday() + 1 if now_local.weekday() < 6 else 0
+            start_of_week_local = now_local - datetime.timedelta(days=days_since_sunday)
+            start_of_week_local = start_of_week_local.replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
 
-        start_of_week_utc = start_of_week_local.astimezone(datetime.timezone.utc)
-        now_utc = now_local.astimezone(datetime.timezone.utc)
+            start_of_week_utc = start_of_week_local.astimezone(datetime.timezone.utc)
+            now_utc = now_local.astimezone(datetime.timezone.utc)
 
-        # Format dates to match SQLite's string format
-        start_date_str = start_of_week_utc.strftime("%Y-%m-%d %H:%M:%S")
-        end_date_str = now_utc.strftime("%Y-%m-%d %H:%M:%S")
+            # Format dates to match SQLite's string format
+            start_date_str = start_of_week_utc.strftime("%Y-%m-%d %H:%M:%S")
+            end_date_str = now_utc.strftime("%Y-%m-%d %H:%M:%S")
 
-        users = sqlite_helpers.get_users_as_leaderboard(
-            SQLITE_FILE_NAME, start_date=start_date_str, end_date=end_date_str
-        )
+            users = sqlite_helpers.get_weekly_leaderboard(
+                SQLITE_FILE_NAME, start_date=start_date_str, end_date=end_date_str
+            )
+        else: # Monthly
+            # Set start of month to 1st of the month 12am
+            start_of_month_local = now_local.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            start_of_month_utc = start_of_month_local.astimezone(datetime.timezone.utc)
+            now_utc = now_local.astimezone(datetime.timezone.utc)
+
+            # Format dates to match SQLite's string format
+            start_date_str = start_of_month_utc.strftime("%Y-%m-%d %H:%M:%S")
+            end_date_str = now_utc.strftime("%Y-%m-%d %H:%M:%S")
+
+            users = sqlite_helpers.get_monthly_leaderboard(
+                SQLITE_FILE_NAME, start_date=start_date_str, end_date=end_date_str
+            )
+            
         for user in users:
             user["points"] = (
                 user["easy"] * POINTS.get("easy", 1)
                 + user["medium"] * POINTS.get("medium", 3)
                 + user["hard"] * POINTS.get("hard", 5)
             )
-        users_sorted = sorted(users, key=lambda u: u["points"], reverse=True)
+        leaderboard_data = sorted(users, key=lambda u: u["points"], reverse=True)
         MetricsHandler.sign_last_updated.set(int(time.time()))
         MetricsHandler.sign_update_error.set(0)
-        return users_sorted
+        return leaderboard_data
     except Exception as e:
         MetricsHandler.sign_update_error.set(1)
         logger.exception(f"Error fetching leaderboard: {str(e)}")
@@ -174,13 +199,29 @@ def poll_leetcode():
         leetcode_stop_event.wait(POLLING_INTERVAL)
 
 
+def leaderboard_switcher():
+    global current_leaderboard_type
+    while not leaderboard_switch_stop_event.is_set():
+        current_leaderboard_type = (
+            LeaderboardType.MONTHLY
+            if current_leaderboard_type == LeaderboardType.WEEKLY
+            else LeaderboardType.WEEKLY
+        )
+        logger.info(f"now showing {current_leaderboard_type.value} leaderboard")
+          
+        # Sleep but wake up if leaderboard_switch_stop_event is set
+        leaderboard_switch_stop_event.wait(QUERY_SWITCH_INTERVAL)
+
+
 @app.on_event("shutdown")
 def shutdown_event():
     logger.info("you should stop the leetcode thread NOW")
     leetcode_stop_event.set()
+    leaderboard_switch_stop_event.set()
 
 if __name__ == "server":
     threading.Thread(target=poll_leetcode).start()
+    threading.Thread(target=leaderboard_switcher).start()
 
 if __name__ == "__main__":
     sqlite_helpers.maybe_create_table(SQLITE_FILE_NAME)

--- a/server.py
+++ b/server.py
@@ -61,8 +61,8 @@ def weekly_leaderboard():
         start_date_str = start_of_week_utc.strftime("%Y-%m-%d %H:%M:%S")
         end_date_str = now_utc.strftime("%Y-%m-%d %H:%M:%S")
 
-        users = sqlite_helpers.get_weekly_leaderboard(
-            SQLITE_FILE_NAME, start_date=start_date_str, end_date=end_date_str
+        users = sqlite_helpers.get_users_as_leaderboard(
+            SQLITE_FILE_NAME, start_date=start_date_str, end_date=end_date_str, weekly=True
         )   
             
         for user in users:
@@ -96,8 +96,8 @@ def monthly_leaderboard():
         start_date_str = start_of_month_utc.strftime("%Y-%m-%d %H:%M:%S")
         end_date_str = now_utc.strftime("%Y-%m-%d %H:%M:%S")
 
-        users = sqlite_helpers.get_monthly_leaderboard(
-            SQLITE_FILE_NAME, start_date=start_date_str, end_date=end_date_str
+        users = sqlite_helpers.get_users_as_leaderboard(
+            SQLITE_FILE_NAME, start_date=start_date_str, end_date=end_date_str, weekly=False
         )
 
         for user in users:

--- a/server.py
+++ b/server.py
@@ -32,7 +32,7 @@ with open(arguments.config, "r") as stream:
     try:
         data = yaml.safe_load(stream)
         API_KEY = data.get("api_key", "NOTHING_REALLY")
-        POLLING_INTERVAL = data.get("leetcode_polling_interval", "300")
+        POLLING_INTERVAL = data.get("leetcode_polling_interval", 300)
         PORT = data.get("port", 8000)
         SQLITE_FILE_NAME = data.get("sqlite3_file_name", "users.db")
         TIME_ZONE = data.get("local_timezone", "UTC")

--- a/server.py
+++ b/server.py
@@ -215,7 +215,6 @@ def poll_leetcode():
 def shutdown_event():
     logger.info("you should stop the leetcode thread NOW")
     leetcode_stop_event.set()
-    leaderboard_switch_stop_event.set()
 
 if __name__ == "server":
     threading.Thread(target=poll_leetcode).start()

--- a/server.py
+++ b/server.py
@@ -109,8 +109,8 @@ async def add_user(request: Request):
     try:
         data = await request.json()
         username = data.get("username", "")
-        first_name = data.get("first_name", "unknown")
-        last_name = data.get("last_name", "unknown")
+        first_name = data.get("firstName", "unknown")
+        last_name = data.get("lastName", "unknown")
         if not username:
             raise HTTPException(status_code=400, detail="Username must be populated")
         if sqlite_helpers.check_if_user_exists(SQLITE_FILE_NAME, username):

--- a/server_config.yml
+++ b/server_config.yml
@@ -3,7 +3,6 @@ leetcode_polling_interval: 300 # query LeetCode every 5 minutes
 port: 8000
 sqlite3_file_name: users.db
 local_timezone: America/Los_Angeles
-query_switch_interval: 600 # toggle monthly/weekly every 10 minutes
 
 points:
   easy: 1

--- a/server_config.yml
+++ b/server_config.yml
@@ -3,6 +3,7 @@ leetcode_polling_interval: 300 # query LeetCode every 5 minutes
 port: 8000
 sqlite3_file_name: users.db
 local_timezone: America/Los_Angeles
+query_switch_interval: 600 # toggle monthly/weekly every 10 minutes
 
 points:
   easy: 1


### PR DESCRIPTION
addresses issue #11 

main endpoint now switches between weekly/monthly data every X seconds (set to 600 / 10 minutes default) , changed "user" field to "username" in sqlite helpers and text-example.cc